### PR TITLE
Fix import bug and handle optional deps

### DIFF
--- a/app/ml/recommendation.py
+++ b/app/ml/recommendation.py
@@ -2,24 +2,45 @@
 import pickle
 import os
 import logging
-import numpy as np
-from sklearn.preprocessing import OneHotEncoder
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - optional dependency
+    np = None
+
+try:
+    from sklearn.preprocessing import OneHotEncoder
+except Exception:  # pragma: no cover - optional dependency
+    OneHotEncoder = None
 from sqlalchemy.orm import Session
 from app.db.models.measure import Measure
 from app.db.models.user import User
-import pandas as pd
+
+try:
+    import pandas as pd
+except Exception:  # pragma: no cover - optional dependency
+    pd = None
 
 logger = logging.getLogger(__name__)
 MODEL_PATH = os.path.join(os.path.dirname(__file__), 'models', 'recommendation_model.pkl')
 ENCODER_PATH = os.path.join(os.path.dirname(__file__), 'models', 'encoder.pkl')
 
-with open(MODEL_PATH, 'rb') as f:
-    model = pickle.load(f)
-
-with open(ENCODER_PATH, 'rb') as f:
-    encoder = pickle.load(f)
+model = None
+encoder = None
+if np is not None and os.path.exists(MODEL_PATH) and os.path.exists(ENCODER_PATH):
+    try:
+        with open(MODEL_PATH, 'rb') as f:
+            model = pickle.load(f)
+        with open(ENCODER_PATH, 'rb') as f:
+            encoder = pickle.load(f)
+    except Exception as e:  # pragma: no cover - model loading is optional
+        logger.warning("Failed to load recommendation model: %s", e)
 
 def get_recommendations(user: User, db: Session):
+    """Return recommended measures for a user."""
+    if model is None or np is None:
+        logger.warning("Recommendation model is not available")
+        return []
+
     features = extract_features(user)
     probabilities = model.predict_proba(features)[0]
     top_indices = np.argsort(probabilities)[::-1][:10]
@@ -28,15 +49,29 @@ def get_recommendations(user: User, db: Session):
     logger.info("Рекомендации успешно сгенерированы для пользователя %s", user.username)
     return measures
 
+class _SimpleFeatures:
+    """Fallback container used when pandas is unavailable."""
+
+    def __init__(self, row: dict):
+        self._row = row
+
+    @property
+    def shape(self):
+        return (1, len(self._row))
+
+
 def extract_features(user):
+    """Extract user features for the recommendation model."""
     features = {
         'region': user.region,
         'industry': user.industry,
         'company_size': user.company_size,
-        'okved': user.okved,
-        'employees_number': user.employees_number,
+        'okved': getattr(user, 'okved', None),
+        'employees_number': getattr(user, 'employees_number', None),
     }
-    return pd.DataFrame([features])
+    if pd is not None:
+        return pd.DataFrame([features])
+    return _SimpleFeatures(features)
 
 def get_measures_from_predictions(predictions, db: Session):
     measures = []

--- a/app/services/fns_api.py
+++ b/app/services/fns_api.py
@@ -1,4 +1,5 @@
 import requests
+from app.core.config import settings
 
 FNS_API_URL = "https://api-fns.ru/api/egr"
 FNS_API_KEY = settings.FNS_API_KEY  # Добавьте API ключ в настройки


### PR DESCRIPTION
## Summary
- fix missing import in FNS API service
- make recommendation module robust to absent ML dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6842a5300e748331a600aff44073d908